### PR TITLE
Combined interfaces

### DIFF
--- a/cmd/unsharemounts/main.go
+++ b/cmd/unsharemounts/main.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/protobuf/gendesc/gendesc.go
+++ b/protobuf/gendesc/gendesc.go
@@ -185,7 +185,7 @@ func genField(f *ast.Field) (*pb.FieldDescriptorProto, *pb.DescriptorProto, erro
 					Tag:      2,
 				},
 			},
-			Up: f.Up,
+			Up: f.Up.(*ast.Message),
 		}
 		vmsg.Fields[0].Up = vmsg
 		vmsg.Fields[1].Up = vmsg

--- a/protobuf/parser/parser.go
+++ b/protobuf/parser/parser.go
@@ -589,7 +589,7 @@ parseFromFieldName:
 			Position: p.cur.astPosition(),
 			Name:     f.Name,
 			Group:    true,
-			Up:       f.Up,
+			Up:       f.Up.(*ast.Message),
 		}
 		if err := p.readMessageContents(group); err != nil {
 			return err


### PR DESCRIPTION
Introduces several 'or' types in order to allow functions and methods which accept more than one AST node type to work with a single argument. Also marks Linux-only build files as such so builds can proceed on Mac OS.
